### PR TITLE
feat(book-viewer): add reading/explore mode toggle

### DIFF
--- a/src/components/BookModel.tsx
+++ b/src/components/BookModel.tsx
@@ -192,16 +192,11 @@ function Page3D({
 
       {/* Front content (visible when page is facing right, not yet flipped past 50%) */}
       {!showBackContent && (
-        <Html
-          position={[pageCenterX, 0, 0.01]}
-          transform
-          distanceFactor={3.5}
-          className={`page-content ${isReadingMode ? "reading-mode" : "explore-mode"}`}
-        >
+        <Html position={[pageCenterX, 0, 0.01]} transform distanceFactor={3.5}>
           {/* biome-ignore lint/a11y/noStaticElementInteractions: 3D content click */}
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: 3D content click */}
           <div
-            className="page-content-inner"
+            className={`page-content-inner ${isReadingMode ? "reading-mode" : "explore-mode"}`}
             onClick={isReadingMode ? undefined : onFlipForward}
           >
             {frontContent}
@@ -217,12 +212,11 @@ function Page3D({
           rotation={[0, Math.PI, 0]}
           transform
           distanceFactor={3.5}
-          className={`page-content ${isReadingMode ? "reading-mode" : "explore-mode"}`}
         >
           {/* biome-ignore lint/a11y/noStaticElementInteractions: 3D content click */}
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: 3D content click */}
           <div
-            className="page-content-inner"
+            className={`page-content-inner ${isReadingMode ? "reading-mode" : "explore-mode"}`}
             onClick={isReadingMode ? undefined : onFlipBackward}
           >
             {backContent}

--- a/src/components/BookModel.tsx
+++ b/src/components/BookModel.tsx
@@ -24,6 +24,7 @@ interface BookModelProps {
   currentPage: number;
   onNextPage?: () => void;
   onPrevPage?: () => void;
+  isReadingMode?: boolean;
 }
 
 interface Page3DProps {
@@ -34,6 +35,7 @@ interface Page3DProps {
   backContent?: ReactNode;
   onFlipForward: () => void;
   onFlipBackward: () => void;
+  isReadingMode: boolean;
 }
 
 /**
@@ -91,6 +93,7 @@ function Page3D({
   backContent,
   onFlipForward,
   onFlipBackward,
+  isReadingMode,
 }: Page3DProps) {
   const meshRef = useRef<THREE.Mesh>(null);
 
@@ -193,11 +196,14 @@ function Page3D({
           position={[pageCenterX, 0, 0.01]}
           transform
           distanceFactor={3.5}
-          className="page-content"
+          className={`page-content ${isReadingMode ? "reading-mode" : "explore-mode"}`}
         >
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: 3D page content */}
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: 3D page content */}
-          <div className="page-content-inner" onClick={onFlipForward}>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: 3D content click */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: 3D content click */}
+          <div
+            className="page-content-inner"
+            onClick={isReadingMode ? undefined : onFlipForward}
+          >
             {frontContent}
             <div className="page-number">{index * 2 + 1}</div>
           </div>
@@ -211,11 +217,14 @@ function Page3D({
           rotation={[0, Math.PI, 0]}
           transform
           distanceFactor={3.5}
-          className="page-content"
+          className={`page-content ${isReadingMode ? "reading-mode" : "explore-mode"}`}
         >
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: 3D page content */}
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: 3D page content */}
-          <div className="page-content-inner" onClick={onFlipBackward}>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: 3D content click */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: 3D content click */}
+          <div
+            className="page-content-inner"
+            onClick={isReadingMode ? undefined : onFlipBackward}
+          >
             {backContent}
             <div className="page-number">{index * 2 + 2}</div>
           </div>
@@ -282,6 +291,7 @@ export function BookModel({
   currentPage,
   onNextPage,
   onPrevPage,
+  isReadingMode = true,
 }: BookModelProps) {
   const groupRef = useRef<THREE.Group>(null);
 
@@ -308,6 +318,7 @@ export function BookModel({
           backContent={page.back}
           onFlipForward={() => onNextPage?.()}
           onFlipBackward={() => onPrevPage?.()}
+          isReadingMode={isReadingMode}
         />
       ))}
 

--- a/src/components/BookViewer.tsx
+++ b/src/components/BookViewer.tsx
@@ -1,6 +1,6 @@
 import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Lock, Unlock } from "lucide-react";
 import { useState } from "react";
 import type { BookViewerProps } from "../types";
 import { BookModel } from "./BookModel";
@@ -30,6 +30,9 @@ export function BookViewer({
   showShadows = true,
 }: BookViewerProps) {
   const [currentPage, setCurrentPage] = useState(initialPage);
+  // Reading mode: camera locked, text selection enabled
+  // Explore mode: OrbitControls enabled, page click to flip
+  const [isReadingMode, setIsReadingMode] = useState(true);
   const totalPages = pages.length;
 
   /**
@@ -93,10 +96,11 @@ export function BookViewer({
             currentPage={currentPage}
             onNextPage={handleNext}
             onPrevPage={handlePrev}
+            isReadingMode={isReadingMode}
           />
 
-          {/* Optional orbit controls for debugging/viewing */}
-          {cameraControls && <OrbitControls />}
+          {/* OrbitControls enabled in explore mode or when cameraControls prop is true */}
+          {(!isReadingMode || cameraControls) && <OrbitControls />}
         </Canvas>
       </div>
 
@@ -157,6 +161,28 @@ export function BookViewer({
             {page.tabLabel || page.id}
           </button>
         ))}
+      </div>
+
+      {/* Mode Toggle Button */}
+      <div className="absolute left-4 top-4 z-40">
+        <button
+          type="button"
+          onClick={() => setIsReadingMode(!isReadingMode)}
+          aria-label={
+            isReadingMode ? "Switch to explore mode" : "Switch to reading mode"
+          }
+          className="bg-stone-800/80 hover:bg-stone-700 text-white p-3 rounded-lg backdrop-blur border border-stone-700 transition-all flex items-center gap-2"
+          title={
+            isReadingMode
+              ? "Explore mode: drag to rotate, scroll to zoom"
+              : "Reading mode: select text, scroll content"
+          }
+        >
+          {isReadingMode ? <Unlock size={20} /> : <Lock size={20} />}
+          <span className="text-xs">
+            {isReadingMode ? "Explore" : "Reading"}
+          </span>
+        </button>
       </div>
     </div>
   );

--- a/src/components/BookViewer.tsx
+++ b/src/components/BookViewer.tsx
@@ -99,8 +99,13 @@ export function BookViewer({
             isReadingMode={isReadingMode}
           />
 
-          {/* OrbitControls enabled in explore mode or when cameraControls prop is true */}
-          {(!isReadingMode || cameraControls) && <OrbitControls />}
+          {/* OrbitControls: always mounted but disabled in reading mode */}
+          <OrbitControls
+            enabled={!isReadingMode || cameraControls}
+            enableRotate={!isReadingMode || cameraControls}
+            enableZoom={!isReadingMode || cameraControls}
+            enablePan={!isReadingMode || cameraControls}
+          />
         </Canvas>
       </div>
 
@@ -178,9 +183,9 @@ export function BookViewer({
               : "Reading mode: select text, scroll content"
           }
         >
-          {isReadingMode ? <Unlock size={20} /> : <Lock size={20} />}
+          {isReadingMode ? <Lock size={20} /> : <Unlock size={20} />}
           <span className="text-xs">
-            {isReadingMode ? "Explore" : "Reading"}
+            {isReadingMode ? "Reading" : "Explore"}
           </span>
         </button>
       </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -114,7 +114,7 @@ const rootElement = document.getElementById("root");
 if (rootElement) {
   createRoot(rootElement).render(
     <StrictMode>
-      <BookViewer pages={samplePages} cameraControls />
+      <BookViewer pages={samplePages} />
     </StrictMode>
   );
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -65,24 +65,20 @@
   @apply border-l-4 border-stone-300 pl-4 italic text-stone-600 mb-4;
 }
 
-/* 3D page content container (Html component wrapper) */
-.page-content {
-  pointer-events: auto;
-}
-
-/* Reading mode: enable text selection and scrolling */
-.page-content.reading-mode .page-content-inner {
+/* Reading mode: enable text selection */
+.page-content-inner.reading-mode {
   cursor: text;
   user-select: text;
 }
 
 /* Explore mode: clickable for page flip */
-.page-content.explore-mode .page-content-inner {
+.page-content-inner.explore-mode {
   cursor: pointer;
   user-select: none;
 }
 
 .page-content-inner {
+  pointer-events: auto;
   position: relative;
   width: 280px;
   height: 400px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -70,25 +70,50 @@
   pointer-events: auto;
 }
 
+/* Reading mode: enable text selection and scrolling */
+.page-content.reading-mode .page-content-inner {
+  cursor: text;
+  user-select: text;
+}
+
+/* Explore mode: clickable for page flip */
+.page-content.explore-mode .page-content-inner {
+  cursor: pointer;
+  user-select: none;
+}
+
 .page-content-inner {
   position: relative;
   width: 280px;
   height: 400px;
-  overflow: hidden;
-  overflow: clip;
+  overflow-y: auto;
+  overflow-x: hidden;
   background: #fffef5;
   color: #2c1a16;
   font-family: Georgia, Cambria, "Times New Roman", Times, serif;
   font-size: 14px;
   line-height: 1.5;
   padding: 20px;
+  padding-bottom: 40px;
   box-sizing: border-box;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
 }
 
+/* Thin scrollbar styling */
 .page-content-inner::-webkit-scrollbar {
-  display: none;
+  width: 4px;
+}
+
+.page-content-inner::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.page-content-inner::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 2px;
+}
+
+.page-content-inner::-webkit-scrollbar-thumb:hover {
+  background: #aaa;
 }
 
 .page-content-inner h1 {

--- a/tests/components/BookViewer.test.tsx
+++ b/tests/components/BookViewer.test.tsx
@@ -174,6 +174,42 @@ describe("BookViewer", () => {
     });
   });
 
+  describe("mode toggle", () => {
+    it("renders mode toggle button", () => {
+      render(<BookViewer pages={mockPages} />);
+      expect(
+        screen.getByLabelText("Switch to explore mode")
+      ).toBeInTheDocument();
+    });
+
+    it("starts in reading mode by default", () => {
+      render(<BookViewer pages={mockPages} />);
+      expect(screen.getByText("Reading")).toBeInTheDocument();
+    });
+
+    it("toggles to explore mode when button is clicked", () => {
+      render(<BookViewer pages={mockPages} />);
+      const toggleButton = screen.getByLabelText("Switch to explore mode");
+
+      fireEvent.click(toggleButton);
+
+      expect(screen.getByText("Explore")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Switch to reading mode")
+      ).toBeInTheDocument();
+    });
+
+    it("toggles back to reading mode when clicked again", () => {
+      render(<BookViewer pages={mockPages} />);
+      const toggleButton = screen.getByLabelText("Switch to explore mode");
+
+      fireEvent.click(toggleButton);
+      fireEvent.click(screen.getByLabelText("Switch to reading mode"));
+
+      expect(screen.getByText("Reading")).toBeInTheDocument();
+    });
+  });
+
   describe("edge cases", () => {
     it("handles empty pages array", () => {
       render(<BookViewer pages={[]} />);

--- a/tests/components/BookViewer.test.tsx
+++ b/tests/components/BookViewer.test.tsx
@@ -208,6 +208,23 @@ describe("BookViewer", () => {
 
       expect(screen.getByText("Reading")).toBeInTheDocument();
     });
+
+    it("enables OrbitControls when cameraControls prop is true even in reading mode", () => {
+      render(<BookViewer pages={mockPages} cameraControls />);
+      // In reading mode with cameraControls=true, should still show Reading label
+      expect(screen.getByText("Reading")).toBeInTheDocument();
+      // Canvas should be rendered (OrbitControls is inside)
+      expect(document.querySelector("canvas")).toBeInTheDocument();
+    });
+
+    it("shows explore mode UI after toggle with cameraControls enabled", () => {
+      render(<BookViewer pages={mockPages} cameraControls />);
+      const toggleButton = screen.getByLabelText("Switch to explore mode");
+
+      fireEvent.click(toggleButton);
+
+      expect(screen.getByText("Explore")).toBeInTheDocument();
+    });
   });
 
   describe("edge cases", () => {


### PR DESCRIPTION
## Summary
- Add toggle button to switch between Reading and Explore modes
- **Reading mode** (default): Camera locked, text selection enabled, page content scrolling enabled
- **Explore mode**: OrbitControls enabled for camera rotation/zoom, page click triggers page flip

## Test plan
- [ ] Verify Reading mode allows text selection and content scrolling
- [ ] Verify Explore mode enables camera rotation (drag) and zoom (scroll)
- [ ] Verify page click flips pages in Explore mode
- [ ] Verify mode toggle button switches between modes correctly

Closes #23